### PR TITLE
Test with multiple event loops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ python:
   - "3.6"
   - "3.7-dev"
   - "nightly"
-
+env:
+  - LOOP=asyncio
+  - LOOP=uvloop
 install:
+  - if [[ "$LOOP" != "asyncio" ]]; then pip install $LOOP; fi;
   - pip install .
   - pip install -r requirements.txt
 script:


### PR DESCRIPTION
It's worthwhile to test this library with multiple event loops to avoid regressions on alternative implementations such as uvloop.