### PR TITLE
Minor optimizations

### DIFF
--- a/distex/pool.py
+++ b/distex/pool.py
@@ -75,47 +75,47 @@ class LoopType(IntEnum):
 class Pool:
     """
     .. warning::
-    
+
        Use a non-ssh process pool only in a trusted network environment.
        Both the pool and the spawning server can in principle allow anyone
        on the network to run arbitrary code.
 
     Pool of local and remote workers that can run tasks.
-    
-    To create a process pool of 4 local workers: 
+
+    To create a process pool of 4 local workers:
 
     .. code-block:: python
-    
+
         pool = Pool(4)
-    
+
     To create 8 remote workers on host ``maxi``, using SSH (unix only):
-        
+
     .. code-block:: python
-    
+
         pool = Pool(0, ['ssh://maxi/8'])
-        
+
     Note that distex must be installed on all remote hosts.
     When using SSH it is not necessary to have a distex server running
     on the hosts. When not using SSH a spawning server has to be started
     first on all hosts involved:
-    
+
     .. code-block:: python
-    
+
         python3 -m distex.server
-    
+
     With the server running on host ``mini``,
     to create a pool of 2 workers running there:
-     
+
     .. code-block:: python
-    
+
         pool = Pool(0, ['mini/2'])
-    
+
     Local, remote SSH and remote non-SSH workers can all be combined in one pool:
-     
+
     .. code-block:: python
-    
+
         pool = Pool(4, ['ssh://maxi/8', 'mini/2'])
-    
+
     To give a SSH username or a non-default port such as 10022, specify the
     host as ``'ssh://username@maxi:10022/8'``.
     It is not possible to give a password,
@@ -140,7 +140,7 @@ class Pool:
             loop=None):
         """
         Parameters:
-        
+
         * ``num_workers``: Number of local process workers. The default of
           None will use the number of CPUs.
         * ``hosts``: List of remote host specification strings in the format
@@ -148,7 +148,7 @@ class Pool:
         * ``qsize``: Number of pending tasks per worker.
           To improve the throughput of small tasks this can be increased
           from the default of 2.
-          If no queueing is desired then it can be set to 1. 
+          If no queueing is desired then it can be set to 1.
         * ``initializer``: Callable to initialize worker processes.
         * ``initargs``: Arguments tuple that is unpacked into the initializer.
         * ``localhost``: Local TCP server (if any) will listen on this address.
@@ -166,15 +166,15 @@ class Pool:
             ``PickleType`` to set the  respective pickle modules to use \
             for serializing functions and for serializing data \
             (data meaning task arguments and results).
-            
+
             0. pickle
             1. cloudpickle
             2. dill
         * ``loop``: The asyncio event loop to run the pool in.
-             
+
         ``distex.Pool`` implements the concurrent.futures.Executor interface
         and can be used in the place of ProcessPoolExecutor.
-        
+
         .. _ssh-keygen: https://linux.die.net/man/1/ssh-keygen
         .. _ssh-copy-id: https://linux.die.net/man/1/ssh-copy-id
         """
@@ -330,7 +330,7 @@ class Pool:
         worker = Worker(serializer, self._loop)
         worker.disconnected = self._on_worker_disconnected
         self._workers.append(worker)
-        self._slots.extend([worker] * self._qsize)
+        self._slots.extend((worker,) * self._qsize)
         self._worker_added.set()
         self._worker_added.clear()
         return worker
@@ -341,7 +341,7 @@ class Pool:
     def is_ready(self) -> bool:
         """
         True if the pool is ready to process tasks, false otherwise.
-        
+
         There is also the public ``ready`` event.
         """
         return self.ready.is_set()
@@ -356,7 +356,7 @@ class Pool:
         """
         Submit the task to be run in the pool and return a
         concurrent.futures.Future that will hold the result.
-        
+
         This method is provided for compatibility with
         concurrent.futures.Executor.
         """
@@ -377,39 +377,39 @@ class Pool:
         """
         Map the function onto the given iterable(s) and
         return an iterator that yields the results.
-        
+
         Parameters:
-        
+
         * ``func`` is a callable. If what the callable returns
           is awaitable then it will be awaited and the result is returned.
-          
+
         * ``iterables``: Sync or async iterables (in any combination)
           that yield the arguments for ``func``. The iterables can
           be unbounded (i.e. they don't need to have a length).
-        
+
         * ``timeout``: Timeout in seconds since map is started.
-        
+
         * ``chunksize``: Iterator will be chunked up to this size.
           A larger chunksize can greatly improve efficiency for small tasks.
-        
+
         * ``ordered``: If true then the order of results preserves the
           order of the input iterables. If false then the results are
           in order of completion. It is more efficient to use ordered=True.
-        
+
         * ``star``: If true then there can be only one iterable and it must
           yield sequences (such as tuples). The sequences will be
           unpacked ('starred') into ``func``.
           If false then the values that the iterators yield will be supplied
           in-place to ``func``.
-          
+
         .. tip::
-        
+
            The function ``func`` is is pickled only once and then cached.
            If it takes arguments that remain constant during the mapping then
            consider using ``functools.partial`` to bind the function with the
            constant arguments; Then do the mapping with the bound function and
            with lesser arguments. Especially when map uses large constant
-           datasets this can be beneficial. 
+           datasets this can be beneficial.
 
         """
         run = self._loop.run_until_complete
@@ -544,10 +544,10 @@ class Pool:
         Run the task on each worker in the pool. Return a list of all results
         (in order of completion) or raise an exception in case the task fails
         on one or more workers.
-        
+
         Will first wait for any other pending tasks to finish and then
         schedule the task over all workers at the same time.
-        
+
         This can be used for initializing, cleanup, intermittent polling, etc.
         """
         return self._loop.run_until_complete(

--- a/distex/slotpool.py
+++ b/distex/slotpool.py
@@ -23,8 +23,9 @@ class SlotPool:
         """
         if not slots:
             return
-        self.capacity += len(slots)
-        self.num_free += len(slots)
+        slots_length = len(slots)
+        self.capacity += slots_length
+        self.num_free += slots_length
         self._slots.appendleft(slots[0])
         self._slots.extend(slots[1:])
         self._wake_up_next()


### PR DESCRIPTION
A few minor optimizations:

* a small optimization that avoids calling `len(slots)` twice.
* Extend the slots pool with a tuple of workers instead of a list.
  The performance difference is in nanoseconds but it took me just a second to make the change.

> In [4]: %timeit l=[];l.extend((foo,) * 6)
> 166 ns ± 3.72 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
> 
> In [5]: %timeit l=[];l.extend([foo,] * 6)
> 191 ns ± 0.823 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

